### PR TITLE
Cache busting for blocks files

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,9 +315,9 @@
         <script src="js/ace/ace.js?version=1.2.1" type="text/javascript" charset="utf-8"></script>
         <script src="js/ace/ext-language_tools.js?version=1.2.1"></script>
 
-        <script src="js/xrp_blocks.js"></script>
-        <script src="js/xrp_blocks_python.js"></script>
-        <script src="js/xrp_blockly_toolbox.js"></script>
+        <script src="js/xrp_blocks.js?version=1.2.1"></script>
+        <script src="js/xrp_blocks_python.js?version=1.2.1"></script>
+        <script src="js/xrp_blockly_toolbox.js?version=1.2.1"></script>
 
         <script src="js/editor_wrapper.js?version=1.2.1"></script>
         <script src="js/filesystem_wrapper.js?version=1.2.1"></script>


### PR DESCRIPTION
The blocks files for Blockly did not have version numbers in the Index.html to cache bust them.