### PR TITLE
Fix for updating beta version of MP

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,13 @@ import { configNonBeta } from './nonbetaConfig.js';
 
 const showChangelogVersion = "1.2.1";  //update all instances of ?version= in the index file to match the version. This is needed for local cache busting
 window.latestMicroPythonVersion = [1, 25, 0];
+
+// this is needed because version 1.25.0 is not released yet and so the version number is not changing. Some boards
+// got shipped with a version before this beta06. So this will help.
+window.latestMicroPythonVersionPlus = "beta06"
+//Set to true if latestMicroPythonVersionPlus is empty.
+window.MPVersionPlus = false;
+
 window.xrpID = "";
 
 
@@ -751,7 +758,7 @@ function registerShell(_container, state){
                 return;
             }
         }
-        var message = "The MicroPython on your XRP needs to be updated. The new version is " + window.latestMicroPythonVersion[0] + "." + window.latestMicroPythonVersion[1] + "." + window.latestMicroPythonVersion[2];
+        var message = "The MicroPython on your XRP needs to be updated. The new version is " + window.latestMicroPythonVersion[0] + "." + window.latestMicroPythonVersion[1] + "." + window.latestMicroPythonVersion[2] + " " + window.latestMicroPythonVersionPlus;
         if(REPL.BLE_DEVICE != undefined){
             message += "<br>You will need to connect your XRP with a USB cable in order to update MicroPython";
             await alertMessage(message);

--- a/js/repl.js
+++ b/js/repl.js
@@ -1170,7 +1170,8 @@ class ReplJS{
                     "            break\n" +
                     "except:\n" +
                     "    print(\"ERROR EX\")\n" +
-                    "print(''.join(['{:02x}'.format(b) for b in machine.unique_id()]));";
+                    "print(''.join(['{:02x}'.format(b) for b in machine.unique_id()]))\n" +
+                    "print(sys.version)";
                    
 
         var hiddenLines = await this.writeUtilityCmdRaw(cmd, true, 1);
@@ -1188,7 +1189,17 @@ class ReplJS{
                 } else if (hiddenLines[1].includes('RP2040')) {
                     this.PROCESSOR = 2040;
                 }
-                
+
+                if(window.latestMicroPythonVersionPlus != ""){
+                    if(hiddenLines[4].includes(window.latestMicroPythonVersionPlus)){
+                        window.MPversionPlus = true;
+                    }
+                    else{
+                        window.MPversionPlus = false;
+                    }
+                }
+
+
                 return [hiddenLines[0].substring(2), hiddenLines[2], hiddenLines[3]];
             }else{
                 console.error("Error getting version information");
@@ -1388,7 +1399,7 @@ class ReplJS{
 
         info[0]= info[0].replace(/[\(\)]/g, "").replace(/,\s/g, "."); //convert to a semantic version
         //if the microPython is out of date
-        if(this.isVersionNewer(window.latestMicroPythonVersion, info[0])){
+        if(this.isVersionNewer(window.latestMicroPythonVersion, info[0]) || window.MPversionPlus == false){
             // Need to update MicroPython
             //alert("Need to update Micropython")
             await this.showMicropythonUpdate();


### PR DESCRIPTION
We currently need MP 1.25.0 that is not released so the version number is not updated. This will look for version beta06. If it is not found then it will update even if the version number is correct.